### PR TITLE
qbot | ranklist Plugin

### DIFF
--- a/ranklist/LICENSE
+++ b/ranklist/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 TypicallyShad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ranklist/ranklist.js
+++ b/ranklist/ranklist.js
@@ -1,0 +1,20 @@
+// Command made by TypicallyShadow
+// Any suggestions? Feel free to contact me.
+// Feel free to change any of the footers but do not claim that you made this command as it can be completely rude.
+
+const roblox = require("noblox.js");
+const Discord = require("discord.js");
+require('dotenv').config();
+
+exports.run = async (client, message, args) => {
+    const getRoles = await roblox.getRoles(Number(process.env.groupId))
+    const formattedRoles = getRoles.map((r) => `\`${r.name}\` - ${r.rank} **(${r.memberCount})**`);
+
+    const rankListEmbed = new Discord.MessageEmbed() 
+      .setTitle('Rank Information:')
+      .setAuthor(message.author.tag, message.author.displayAvatarURL())
+      .setColor(8311585)
+      .setDescription(formattedRoles)
+      .setFooter(`qbot | Plugin by TypicallyShadow`);
+    message.channel.send(rankListEmbed)
+}

--- a/ranklist/readme.md
+++ b/ranklist/readme.md
@@ -1,0 +1,9 @@
+# qbot ranklist plugin
+This plugin gets all the ranks in your group and will post it in an embed, including the roleset and also how many people are in the role.
+
+## Instructions
+* Add the MIT license into your editor/host from this repository located in the `ranklist` folder.
+* Make a file named `ranklist.js` inside of the `commands` folder.
+* Copy and paste code from `ranklist.js` found on this repository into your editor/host.
+
+> Questions or concerns? Contact me at Shad#3200, or in the Support Server.


### PR DESCRIPTION
**Plugin Name:**
ranklist

**Plugin __Short__ Description:**
This plugin gets all the ranks in your group and will post it in an embed, including the roleset and also how many people are in the role.

**Your Discord Tag:**
Shad#3200

**Your Discord ID:**
298014369533657090
